### PR TITLE
Only csv input

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,5 @@
 [flake8]
-exclude = build
+exclude = build,venv
 max_line_length=120
 
 per-file-ignores =

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,9 +39,6 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           architecture: x64
-        # Adopted from https://pypi.org/project/pdftotext/
-      - name: Setup poppler
-        run: sudo apt-get install build-essential libpoppler-cpp-dev pkg-config python-dev
       - name: Install nosetests
         run: pip install nose # for code coverage: coverage
       - name: Run tests

--- a/README.md
+++ b/README.md
@@ -9,6 +9,11 @@ Otherwise, if you can't re-download the invoice, you can use the old version of 
 
 Fixes Hetzner CSV reports by cleaning the CSV and merging project name from PDF.
 
+## Known issues
+
+- In previous versions, the VAT was extracted from the PDF. The current version just processes the CSV, which does not contain the VAT.
+  For compatibility (price_gross column), the VAT is set to 19%.
+
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -1,48 +1,31 @@
-# hetzner-fix-report
+<# hetzner-fix-report
+
+Takes invoice CSV files from Hetzner and changes the formatting, splitting columns which contain various information into multiple columns.
+
+Versions <1.0 took the Hetzner CSV *and* PDF as input, and extracted e.g. project information from the PDF.
+However, today this information is also included in the CSV, so the PDF is no longer needed.
+If you have older invoices, you can re-download them from the Hetzner invoice page in the new format.
+Otherwise, if you can't re-download the invoice, you can use the old version of hetzner-fix-report.
+
 Fixes Hetzner CSV reports by cleaning the CSV and merging project name from PDF.
 
+
 ## Installation
-### Preliminary libraries
 
-Debian, Ubuntu, etc
-
-```
-sudo apt-get install build-essential libpoppler-cpp-dev pkg-config python-dev
-```
-
-Fedora, Red Hat, etc
-
-```
-sudo yum install gcc-c++ pkgconfig poppler-cpp-devel python-devel redhat-rpm-config
-```
-
-Arch, etc
-
-```
-sudo pacman -S poppler
-```
-
-### Python package
 This project is hosted on [PyPI](https://pypi.org/project/hetzner-fix-report/) and can therefore be installed easily through pip:
 
 ```
 pip install hetzner_fix_report
 ```
 
-Dependending on your setup you may need to add `--user` after the install.
+Depending on your setup you may need to add `--user` after the installation.
 
 ## Usage
 ### Single report
-Use the command line interface to combine a `csv` and `pdf` file:
+Use the command line interface to process a `csv` file:
 
 ```
-hetzner-fix-report Hetzner_2020-01-05_RXXXXXXXXXX.csv Hetzner_2020-01-05_RXXXXXXXXXX.pdf
-```
-
-Or shorten it using brace expansion:
-
-```
-hetzner-fix-report Hetzner_2020-01-05_RXXXXXXXXXX.{csv,pdf}
+hetzner-fix-report Hetzner_2020-01-05_RXXXXXXXXXX.csv
 ```
 
 If you want to save the enriched csv output, use either the `-o` parameter as explained in the program's help or redirect output to a file using `>`.
@@ -52,15 +35,13 @@ When in a directory that holds multiple `csv` and `pdf` files the following shel
 
 ```
 mkdir -p fix
-for csv in *.csv; do pdf=${csv%%.*}.pdf; hetzner-fix-report -o "fix/$csv" "$csv" "$pdf"; done
+for csv in *.csv; do hetzner-fix-report -o "fix/$csv" "$csv"; done
 ```
 
 ## Original & enriched format
 Hetzner's original CSV reports have the problem of being unprecise and not machine readable.
-This is especially noticeable in the long multiline comment column that may is mostly human readable.
-Currently the PDF report contains additional information about the entry's (server/backup) associated project.
-Since this information is not contained within the CSV reports I wanted to fix this.
-The enriched format has the following keys and examplary values:
+This is especially noticeable in the long multiline comment column that is mostly human readable.
+The enriched format has the following keys and exemplary values:
 
 Key | Example | New
 :-|:-:| :-:

--- a/bin/hetzner-fix-report
+++ b/bin/hetzner-fix-report
@@ -14,8 +14,7 @@ if __name__ == '__main__':
     parser.add_argument('-f', '--format', help='Format to be used, defaults to CSV', default='csv',
                         choices=['csv', 'pandas'])
     parser.add_argument('-V', '--version', help='Print version number and exit', action='store_true')
-    parser.add_argument('base_csv', help='Path to csv base file', nargs='?')
-    parser.add_argument('base_pdf', help='Path to pdf base file', nargs='?')
+    parser.add_argument('base_csv', help='Path to csv base file')
 
     args = parser.parse_args()
 
@@ -23,17 +22,13 @@ if __name__ == '__main__':
         print(hetzner_fix_report.__version__)
         sys.exit(0)
 
-    if len(sys.argv) < 3:
-        parser.print_help(sys.stderr)
-        sys.exit(1)
-
     # Check if files exists
-    for f in [args.base_csv, args.base_pdf]:
+    for f in [args.base_csv]:
         if not os.path.isfile(f):
             print(f"File not found: {f}")
             sys.exit(1)
 
-    df = hetzner_fix_report.hetzner_fix_report(args.base_csv, args.base_pdf)
+    df = hetzner_fix_report.hetzner_fix_report(args.base_csv)
 
     if args.format == 'csv':
         if not args.output:

--- a/hetzner_fix_report/hetzner_fix_report.py
+++ b/hetzner_fix_report/hetzner_fix_report.py
@@ -50,7 +50,11 @@ def hetzner_fix_report(csv_path):
                        'price_net', 'price_gross', 'vat', 'date_from', 'date_to', 'is_backup', 'is_server', 'is_ceph']
 
     # Load originally fucked CSV
-    df = pd.read_csv(csv_path, sep=',', names=df_keys, converters={'price': Decimal, 'price_net': Decimal, 'quantity': Decimal})
+    df = pd.read_csv(csv_path, sep=',', names=df_keys, converters={
+        'price': Decimal,
+        'price_net': Decimal,
+        'quantity': Decimal,
+    })
 
     # Whether entry is backup
     df['is_backup'] = df.server_type_str.apply(lambda x: 'Backup' in x)

--- a/hetzner_fix_report/hetzner_fix_report.py
+++ b/hetzner_fix_report/hetzner_fix_report.py
@@ -92,7 +92,7 @@ def hetzner_fix_report(csv_path):
 
     # Collect individual server ids' string locations and map them to nearest previous project name
     df['project'] = np.nan
-    for idx, sid in df.server_id[df.server_id.notnull()].items():
+    for idx in df.index:
         df.loc[idx, 'project'] = regex_search(idx, r'Cloud Project "([^"]+)"')
 
     # Reorder columns

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 pbr==5.4.4
-pdftotext>=2.1.4
 numpy>=1.18.4
 pandas>=1.0.3
 regex>=2020.6.8


### PR DESCRIPTION
Fixes #5 

Removes PDF inputs. The output format until revision 967bde6 is the same as version 0.11. I checked by using an output that was generated by the old version ([flipdot transparenz reports](https://github.com/flipdot/transparenz-reports/blob/master/data/running_expenses/hcloud/2022-06-05.csv)) and a new Hetzner PDF with my changes of the packages, comparing a SHA checksum.

After that, I introduced two changes which change the format:
- Use Decimal instead of float. This makes all calculations more precise
- Support more "types". Until now only server types and "backup" were supported.

Unfortunately, the CSV does not contain the VAT. Therefore, I needed to hardcode 19%. But I think it's worth dropping all the PDF dependencies for this. The VAT extraction anyway didn't work anymore with the new PDFs.

# Please, after merging, remember

Tag the version with `v1.0` so it gets published to PyPI